### PR TITLE
refactor (Sheet): removed workaround which resized sheet to 3 rows

### DIFF
--- a/tests/Keboola/GoogleSheetsWriter/FunctionalTest.php
+++ b/tests/Keboola/GoogleSheetsWriter/FunctionalTest.php
@@ -208,7 +208,7 @@ class FunctionalTest extends BaseTest
 
         $process = $this->runProcess($config);
 
-        $this->assertEquals(0, $process->getExitCode(), $process->getOutput());
+        $this->assertEquals(0, $process->getExitCode(), $process->getErrorOutput());
 
         $response = $this->client->getSpreadsheet($gdFile['id']);
         $values = $this->client->getSpreadsheetValues(


### PR DESCRIPTION
Now only values are cleared. And the grid size is gradually increased in a loop.

FIXES #11 .