### PR TITLE
Surface missing input table as UserException instead of internal error

### DIFF
--- a/src/Keboola/GoogleSheetsWriter/Input/Table.php
+++ b/src/Keboola/GoogleSheetsWriter/Input/Table.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Keboola\GoogleSheetsWriter\Input;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Csv\Exception as CsvException;
+use Keboola\GoogleSheetsWriter\Exception\UserException;
 
 class Table
 {
@@ -22,9 +24,18 @@ class Table
     {
         $this->dataDir = $dataDir;
         $this->tableId = $tableId;
-        $this->csvFile = new CsvFile($this->getPathname());
-        $this->rowCount = $this->countLines();
-        $this->columnCount = $this->csvFile->getColumnsCount();
+        try {
+            $this->csvFile = new CsvFile($this->getPathname());
+            $this->rowCount = $this->countLines();
+            $this->columnCount = $this->csvFile->getColumnsCount();
+        } catch (CsvException $e) {
+            throw new UserException(sprintf(
+                'Input table "%s" could not be read (%s). Please check the input mapping and make '
+                . 'sure the table is present on the writer input so it can be written to Google Sheets.',
+                $this->tableId,
+                $e->getMessage(),
+            ), 0, $e);
+        }
     }
 
     public function getPathname(): string

--- a/tests/Keboola/GoogleSheetsWriter/Input/TableTest.php
+++ b/tests/Keboola/GoogleSheetsWriter/Input/TableTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GoogleSheetsWriter\Input;
+
+use Keboola\GoogleSheetsWriter\Exception\UserException;
+use PHPUnit\Framework\TestCase;
+
+class TableTest extends TestCase
+{
+    private const DATA_PATH = __DIR__ . '/../../../data';
+
+    public function testExistingInputTableIsReadable(): void
+    {
+        // Happy path: an input table that is present is read exactly as before.
+        $table = new Table(self::DATA_PATH, 'titanic');
+
+        $this->assertSame(6, $table->getColumnCount());
+        $this->assertGreaterThan(0, $table->getRowCount());
+    }
+
+    public function testMissingInputTableRaisesUserException(): void
+    {
+        // A configured input table that is absent from /data/in/tables must surface as a
+        // UserException (exit 1) instead of an opaque Keboola\Csv\Exception (internal error, exit 2).
+        $emptyDataDir = sys_get_temp_dir() . '/gsheets-wr-test-' . uniqid();
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage('Input table "missing_table" could not be read');
+
+        new Table($emptyDataDir, 'missing_table');
+    }
+}


### PR DESCRIPTION
## What

Surface a missing input table as a clear `UserException` (exit 1) instead of an unhandled `Keboola\Csv\Exception` (exit 2, application/internal error).

## Root cause

When the writer is configured to write a table that is **not present** in `/data/in/tables/`, `Input\Table` opens the CSV via `keboola/csv`. That library opens the file lazily, so `Cannot open file /data/in/tables/<input-table>.csv` (a `Keboola\Csv\Exception`) is thrown while counting rows in the constructor. Nothing caught it, so `run.php` fell through to its final `Throwable` handler and exited with code **2** — an opaque internal error that pages the team and tells the customer nothing, even though the cause (an input table missing from the input mapping) is entirely user-fixable.

- Exception: `Keboola\Csv\Exception: Cannot open file /data/in/tables/<input-table>.csv`
- Crash site: `src/Keboola/GoogleSheetsWriter/Input/Table.php` (constructor, during the input-table load)
- Exit code observed: 2 (internal error)

## Fix

Wrap the input-table load in `Input\Table::__construct` in a narrow `try/catch` on `Keboola\Csv\Exception` and re-raise it as the component's `UserException` (exit 1) with an actionable message pointing at the input mapping. The exception class caught is specific to CSV read failures — not a broad `Throwable` — so unrelated errors are unaffected.

## Behaviour impact: none — defensive-only

- The happy path is **byte-for-byte unchanged**: when the input table is present and readable, none of the wrapped statements throw, the `catch` is never entered, and `csvFile` / `rowCount` / `columnCount` are assigned exactly as before, in the same order.
- No output, schema, data transform, default, or condition on the success path is changed.
- The failure still **fails the job** — it does not return empty or partial output. Only the *manner* of failure changes: opaque exit 2 becomes a legible exit 1 the customer can act on, and the team stops being paged for a config problem.
- No existing test or assertion was modified or removed.

## Tests

Added `tests/Keboola/GoogleSheetsWriter/Input/TableTest.php` (hermetic, no Google credentials required):

- `testMissingInputTableRaisesUserException` — drives the now-handled path and asserts a `UserException` is raised with the actionable message (the regression test for this fix).
- `testExistingInputTableIsReadable` — asserts the happy path still reads a present input table (correct column/row counts).

Verified in the component's Docker image:

- `phpunit` on the new test: 2 tests, 4 assertions, OK.
- `phpstan --level=max` on `src` + `tests`: no errors.
- `phpcs`: clean.

The existing suite (`SheetTest`, `FunctionalTest`) requires live Google OAuth credentials and is validated by CI; it was not modified.
