### PR TITLE
Defensive fix: surface a missing sheetId as a UserException in keboola.wr-google-sheets

### DIFF
--- a/src/Keboola/GoogleSheetsWriter/Writer.php
+++ b/src/Keboola/GoogleSheetsWriter/Writer.php
@@ -6,6 +6,7 @@ namespace Keboola\GoogleSheetsWriter;
 
 use Keboola\GoogleSheetsClient\Client;
 use Keboola\GoogleSheetsWriter\Configuration\ConfigDefinition;
+use Keboola\GoogleSheetsWriter\Exception\UserException;
 use Keboola\GoogleSheetsWriter\Input\TableFactory;
 use Monolog\Logger;
 use Psr\Http\Message\ResponseInterface;
@@ -59,6 +60,21 @@ class Writer
                 if ($sheetCfg['sheetMode'] === ConfigDefinition::SHEET_MODE_ADD) {
                     $sheetProperties = $this->addSheet($sheetCfg);
                     $sheetCfg['sheetId'] = (int) $sheetProperties['sheetId'];
+                }
+
+                // "sheetId" is an optional node in ConfigDefinition and is only filled in by the
+                // "add" branch above, so a sheet left in the default "replace" mode without one
+                // passed config validation and then died in Sheet::process() on an undefined array
+                // key - an opaque internal error that says nothing to the user. Surface the missing
+                // value as a clear user error instead; a configured sheetId is untouched.
+                if (!isset($sheetCfg['sheetId'])) {
+                    throw new UserException(sprintf(
+                        'Sheet "%s" in file "%s" is missing the "sheetId" configuration value. '
+                        . 'Select an existing sheet for this table, or set the sheet mode to "add" '
+                        . 'to have a new sheet created.',
+                        $sheetCfg['sheetTitle'],
+                        $sheetCfg['title'],
+                    ));
                 }
 
                 $sheetWriter = new Sheet(

--- a/tests/Keboola/GoogleSheetsWriter/WriterTest.php
+++ b/tests/Keboola/GoogleSheetsWriter/WriterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GoogleSheetsWriter;
+
+use Keboola\Google\ClientBundle\Google\RestApi;
+use Keboola\GoogleSheetsClient\Client;
+use Keboola\GoogleSheetsWriter\Configuration\ConfigDefinition;
+use Keboola\GoogleSheetsWriter\Exception\UserException;
+use Keboola\GoogleSheetsWriter\Input\TableFactory;
+use Monolog\Handler\NullHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the "sheetId" guard in Writer::process().
+ *
+ * "sheetId" is an optional node in ConfigDefinition and is only populated by the
+ * SHEET_MODE_ADD branch, so a sheet left in the default "replace" mode without one passed
+ * config validation and then died in Sheet::process() with `Undefined array key "sheetId"`
+ * — an opaque internal error (exit 2) that told the user nothing. It is now surfaced as a
+ * UserException (exit 1) naming the sheet and what to set.
+ *
+ * These tests are hermetic: the guard runs before any Drive API or input-table access, so
+ * the mocked Client and TableFactory are never called.
+ */
+class WriterTest extends TestCase
+{
+    private function createWriter(): Writer
+    {
+        $restApi = $this->createMock(RestApi::class);
+        $client = $this->createMock(Client::class);
+        $client->method('getApi')->willReturn($restApi);
+
+        return new Writer(
+            $client,
+            $this->createMock(TableFactory::class),
+            new Logger('test', [new NullHandler()]),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sheetConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'id' => 0,
+            'fileId' => 'some-file-id',
+            'title' => 'titanic',
+            'sheetTitle' => 'casualties',
+            'tableId' => 'in.c-main.titanic',
+            'action' => ConfigDefinition::ACTION_UPDATE,
+            'sheetMode' => ConfigDefinition::SHEET_MODE_REPLACE,
+            'enabled' => true,
+        ], $overrides);
+    }
+
+    public function testMissingSheetIdThrowsUserException(): void
+    {
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Sheet "casualties" in file "titanic" is missing the "sheetId" configuration value. '
+            . 'Select an existing sheet for this table, or set the sheet mode to "add" '
+            . 'to have a new sheet created.',
+        );
+
+        $this->createWriter()->process([$this->sheetConfig()]);
+    }
+
+    public function testNullSheetIdThrowsUserException(): void
+    {
+        // An explicitly null sheetId failed too (a TypeError deeper in Sheet), so converting
+        // it here does not change any previously-succeeding run.
+        $this->expectException(UserException::class);
+
+        $this->createWriter()->process([$this->sheetConfig(['sheetId' => null])]);
+    }
+
+    public function testDisabledSheetIsStillSkippedBeforeTheGuard(): void
+    {
+        // Guards the ordering: the guard must not fire for a disabled sheet, which the
+        // component has always skipped entirely regardless of its configuration.
+        $this->createWriter()->process([$this->sheetConfig(['enabled' => false])]);
+
+        $this->expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
## Summary
Adds defensive handling for an unhandled `ErrorException: Undefined array key "sheetId"`
observed in production. No change to the component's behaviour on inputs that already worked.

## Root cause
`ErrorException: Undefined array key "sheetId"`, raised from
`Sheet::process()` (`src/Keboola/GoogleSheetsWriter/Sheet.php:37`) via `Writer::process()`.
Classified as **user-actionable (exit 2 → 1)**; 2 occurrences in the alert window.

`sheetId` is an **optional** `scalarNode` in `ConfigDefinition` — it has no `isRequired()`
and no default. `Writer::process()` only populates it in the `SHEET_MODE_ADD` branch, and
`sheetMode` defaults to `replace`. So a sheet configured in the default `replace` mode with
no `sheetId` passes config validation, reaches `Sheet::process()`, and dies on the very
first statement — as an opaque internal error (exit 2) that tells the user nothing and pages
the team for what is a configuration problem.

## Fix
Guard the value in `Writer::process()` immediately after the branch that would have
populated it, and raise a `UserException` naming the sheet and file and telling the user what
to set (pick an existing sheet, or switch the sheet mode to `add`).

Placement makes it inert for everything that worked before:
- it sits **inside** the existing `enabled` check, so a disabled sheet is still skipped
  untouched;
- it sits **after** the `SHEET_MODE_ADD` branch, so add-mode sheets — which get their
  `sheetId` from the API — never reach it;
- `Sheet::process()` dereferences `$sheet['sheetId']` unconditionally as its first statement
  for every action, so any configuration that previously completed successfully necessarily
  already had the value.

## Behaviour impact: none — defensive-only
- Happy path unchanged; no outputs, transforms, schema, or config semantics touched.
- The job still fails — the same run that crashed now raises a `UserException`, converting an
  opaque exit-2 internal error into a clear exit-1 user error. Nothing is swallowed.
- No previously-succeeding configuration can newly trip the guard (see the placement note above).
- An explicitly `null` `sheetId` also failed before (a `TypeError` deeper in `Sheet`), so
  covering it here changes no working run either.
- **The diff is 105 insertions and 0 deletions** — nothing existing was edited or removed.

## Evidence
Datadog: https://app.datadoghq.eu/monitors/97152903

## Tests
Added `tests/Keboola/GoogleSheetsWriter/WriterTest.php` — a **hermetic** unit test (the guard
runs before any Drive API or input-table access, so the mocked `Client`/`TableFactory` are
never called). It covers the missing `sheetId`, an explicitly null one, and that a disabled
sheet is still skipped before the guard.

Run in a container (no local PHP):
- `vendor/bin/phpunit --filter=WriterTest` — **3 passed**.
- `vendor/bin/phpstan analyse --level=max src tests -c phpstan.neon` — no errors.
- `vendor/bin/phpcs -n --ignore=vendor --extensions=php .` — clean.

The pre-existing `FunctionalTest`/`SheetTest` suites talk to live Google Drive and cannot run
locally without credentials — they fail in `BaseTest::setUp` on `master` exactly as they do on
this branch (verified by running the suite on both), so that failure is pre-existing and
unrelated to this change. CI, which has the credentials, is the check for those.